### PR TITLE
Add glossary support for better LLM parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,9 @@ node server.js
 * You can also type directly into the text area.
 * Click **Send** to send the text to the server. The server will attempt to parse events with OpenAI if an API key is provided, falling back to storing the raw text otherwise.
 * Parsed events are appended to `game.csv` in the project root.
+
+### Glossary
+
+A small glossary of common ultimate frisbee terms is provided in `glossary.txt`.
+If the file exists, its contents are included in prompts sent to the language
+model to improve parsing accuracy.

--- a/glossary.txt
+++ b/glossary.txt
@@ -1,0 +1,12 @@
+assist - the pass that directly leads to a score
+block - a defensive play that stops a pass
+dump - a short reset pass used to keep possession
+huck - a long throw downfield
+pull - the throw that begins each point
+swing - a lateral pass across the field
+stall - a violation for holding the disc too long
+turnover - when the offense loses possession due to a drop, block or throwaway
+layout - diving for the disc on offense or defense
+handler - a primary thrower who usually stays in the backfield
+cutter - a player making upfield cuts to receive passes
+force - the direction the marker tries to make the thrower release

--- a/server.js
+++ b/server.js
@@ -5,6 +5,14 @@ const fs = require('fs');
 const path = require('path');
 const createCsvWriter = require('csv-writer').createObjectCsvWriter;
 
+// Load glossary of common ultimate frisbee terms if available
+const glossaryPath = path.join(__dirname, 'glossary.txt');
+let glossary = '';
+if (fs.existsSync(glossaryPath)) {
+  glossary = fs.readFileSync(glossaryPath, 'utf8').trim();
+  console.log(`Loaded glossary from ${glossaryPath}`);
+}
+
 const app = express();
 app.use(express.static('public'));
 app.use(bodyParser.json());
@@ -49,9 +57,10 @@ async function parseWithAI(text) {
     // fallback simple parser
     return [{ event: 'raw', details: text }];
   }
-  const prompt = `From the sentence below identify any ultimate frisbee statistics. ` +
-    `Return only a JSON array of objects each with \"player\" and \"stat\" (` +
+  const prompt = `From the sentence below identify any ultimate frisbee statistics.` +
+    ` Return only a JSON array of objects each with "player" and "stat" (` +
     `score, assist, block or turnover). If no stats are present return [].\n` +
+    (glossary ? `Glossary:\n${glossary}\n` : '') +
     `Sentence: ${text}`;
   console.log('Sending prompt to OpenAI:', prompt);
   const resp = await openai.completions.create({


### PR DESCRIPTION
## Summary
- load an optional `glossary.txt` file at startup
- include glossary contents in the OpenAI prompt if present
- document glossary support in README
- add sample glossary of ultimate frisbee terms

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684afcdd3c288323977a233c2aa8eddc