### PR TITLE
Add Yahoo Finance date-grouped lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,29 @@ A small glossary of common ultimate frisbee terms is provided in `glossary.json`
 When the server processes a sentence it scans the text for any glossary terms
 and only includes matching definitions in prompts sent to the language model.
 This keeps prompts concise while still improving parsing accuracy.
+
+## Yahoo Price Lookup
+
+The repository also includes a small helper module `yahoo_prices.py` for
+retrieving historical prices from Yahoo Finance. It expects a dictionary mapping
+`datetime.date` objects to sets of tickers and returns a nested dictionary of
+closing prices for each requested date. Prices are fetched with
+`yfinance` using one request per day that includes all tickers needed on that
+date.
+
+Example usage:
+
+```python
+import datetime
+from yahoo_prices import fetch_prices
+
+dates = {datetime.date(2023, 1, 3): {"AAPL", "MSFT"}}
+prices = fetch_prices(dates)
+print(prices)
+```
+
+Install `yfinance` if needed:
+
+```bash
+pip install yfinance
+```

--- a/yahoo_prices.py
+++ b/yahoo_prices.py
@@ -20,14 +20,18 @@ def fetch_prices(date_to_tickers: Dict[datetime.date, Iterable[str]]) -> Dict[da
         if not tickers:
             continue
 
-        data = yf.download(
-            tickers,
-            start=day,
-            end=day + datetime.timedelta(days=1),
-            group_by="ticker",
-            progress=False,
-            threads=False,
-        )
+        try:
+            data = yf.download(
+                tickers,
+                start=day,
+                end=day + datetime.timedelta(days=1),
+                group_by="ticker",
+                progress=False,
+                threads=False,
+            )
+        except Exception as e:
+            logging.error(f"Failed to fetch data for {day} and tickers {tickers}: {e}")
+            continue
 
         prices: Dict[str, float] = {}
 

--- a/yahoo_prices.py
+++ b/yahoo_prices.py
@@ -1,0 +1,62 @@
+import datetime
+from typing import Dict, Iterable
+import yfinance as yf
+
+
+def fetch_prices(date_to_tickers: Dict[datetime.date, Iterable[str]]) -> Dict[datetime.date, Dict[str, float]]:
+    """Return closing prices for each ticker on each date.
+
+    Yahoo requests are grouped per date with all tickers for that date so the
+    input structure is respected. Each request downloads one day of data for all
+    tickers scheduled on that date.
+    """
+    if not date_to_tickers:
+        return {}
+
+    results: Dict[datetime.date, Dict[str, float]] = {}
+
+    for day, tickers in date_to_tickers.items():
+        tickers = sorted(set(tickers))
+        if not tickers:
+            continue
+
+        data = yf.download(
+            tickers,
+            start=day,
+            end=day + datetime.timedelta(days=1),
+            group_by="ticker",
+            progress=False,
+            threads=False,
+        )
+
+        prices: Dict[str, float] = {}
+
+        if len(tickers) == 1:
+            # Single ticker: DataFrame columns are not MultiIndexed
+            row = data.iloc[0] if not data.empty else None
+            if row is not None:
+                price = row.get("Adj Close", row.get("Close"))
+                if price is not None:
+                    prices[tickers[0]] = float(price)
+        else:
+            for t in tickers:
+                if t in data:
+                    row = data[t].iloc[0] if not data[t].empty else None
+                    if row is not None:
+                        price = row.get("Adj Close", row.get("Close"))
+                        if price is not None:
+                            prices[t] = float(price)
+
+        if prices:
+            results[day] = prices
+
+    return results
+
+
+if __name__ == "__main__":
+    import pprint
+    example = {
+        datetime.date(2023, 1, 3): {"AAPL", "MSFT"},
+        datetime.date(2023, 1, 4): {"AAPL"},
+    }
+    pprint.pprint(fetch_prices(example))


### PR DESCRIPTION
## Summary
- refine `fetch_prices` to batch requests by date rather than by ticker
- update README to describe per-date Yahoo requests

## Testing
- `npm test` *(fails: Error: no test specified)*
- `python yahoo_prices.py` *(fails: ProxyError when contacting Yahoo due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684b1aade8888323ba97f4949d588926