### PR TITLE
Display game log

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ node server.js
 * Click **Start Voice** to begin recording using the browser's speech recognition (Web Speech API). Once you're done speaking, click **Stop Voice**.
 * You can also type directly into the text area.
 * Click **Send** to send the text to the server. The server will attempt to parse events with OpenAI if an API key is provided. If parsing fails for any reason, the text is stored as a raw event instead.
-* Parsed events are appended to `game.csv` in the project root.
+* Parsed events are appended to `public/game.csv` so they can be viewed in the browser.
+* The browser parses this CSV to build a table showing stats per player.
 * Every piece of text you submit is also recorded in `transcript.txt` so you can keep a full log of the game.
 
 ### Glossary

--- a/public/index.html
+++ b/public/index.html
@@ -11,9 +11,72 @@
   <button id="stop">Stop Voice</button>
   <button id="send">Send</button>
   <pre id="output"></pre>
-<script>
+  <h2>Game Log</h2>
+  <table id="stats">
+    <thead>
+      <tr>
+        <th>Player</th>
+        <th>Scores</th>
+        <th>Assists</th>
+        <th>Blocks</th>
+        <th>Turns</th>
+        <th>+/-</th>
+      </tr>
+    </thead>
+    <tbody id="stats-body"></tbody>
+  </table>
+  <script>
 const textArea = document.getElementById('text');
 const output = document.getElementById('output');
+const statsBody = document.getElementById('stats-body');
+
+function parseCsv(text) {
+  const lines = text.trim().split('\n');
+  const players = {};
+  for (const line of lines.slice(1)) {
+    const parts = line.split(',');
+    if (parts.length < 3) continue;
+    const event = parts[1].trim().toLowerCase();
+    const player = parts[2].trim();
+    if (!player) continue;
+    if (!players[player]) {
+      players[player] = { score: 0, assist: 0, block: 0, turn: 0 };
+    }
+    if (event === 'score') players[player].score++;
+    else if (event === 'assist') players[player].assist++;
+    else if (event === 'block') players[player].block++;
+    else if (event === 'turn' || event === 'turnover') players[player].turn++;
+  }
+  return players;
+}
+
+function renderStats(players) {
+  statsBody.innerHTML = '';
+  Object.entries(players).forEach(([name, stats]) => {
+    const pm = stats.score + stats.assist + stats.block - stats.turn;
+    const row = document.createElement('tr');
+    row.innerHTML = `\n      <td>${name}</td>\n      <td>${stats.score}</td>\n      <td>${stats.assist}</td>\n      <td>${stats.block}</td>\n      <td>${stats.turn}</td>\n      <td>${pm}</td>`;
+    statsBody.appendChild(row);
+  });
+}
+
+async function fetchCsv() {
+  try {
+    const res = await fetch('/game.csv');
+    if (!res.ok) {
+      statsBody.innerHTML = '';
+      return;
+    }
+    const text = await res.text();
+    const players = parseCsv(text);
+    renderStats(players);
+  } catch (err) {
+    console.error('Failed to load CSV', err);
+  }
+}
+
+// load CSV on page load
+fetchCsv();
 let recognition;
 if ('webkitSpeechRecognition' in window) {
   recognition = new webkitSpeechRecognition();
@@ -37,6 +100,7 @@ document.getElementById('send').onclick = async () => {
   });
   const data = await res.json();
   output.textContent = JSON.stringify(data, null, 2);
+  await fetchCsv();
 };
 </script>
 </body>

--- a/server.js
+++ b/server.js
@@ -25,7 +25,8 @@ const app = express();
 app.use(express.static('public'));
 app.use(bodyParser.json());
 
-const csvPath = path.join(__dirname, 'game.csv');
+// Store the CSV inside the public folder so it can be fetched by the browser
+const csvPath = path.join(__dirname, 'public', 'game.csv');
 const csvWriter = createCsvWriter({
   path: csvPath,
   header: [


### PR DESCRIPTION
## Summary
- store `game.csv` inside the `public` folder so the browser can read it
- show the CSV on the webpage and refresh it after sending events
- document new CSV location
- parse `game.csv` and display a per-player stats table

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c8a0e733483238e5d76aa615bc565