### PR TITLE
Fix JSON parsing issue from OpenAI

### DIFF
--- a/server.js
+++ b/server.js
@@ -176,8 +176,9 @@ async function parseWithAI(text) {
   const resp = await openai.chat.completions.create({
     model: 'gpt-4.1-mini',
     messages: [{ role: 'user', content: prompt }],
-    max_tokens: 100,
-    temperature: 0
+    max_tokens: 256,
+    temperature: 0,
+    response_format: { type: 'json_object' }
   });
   console.log('OpenAI raw response:', resp);
   console.log('OpenAI raw response text:', resp.choices[0].message.content);


### PR DESCRIPTION
## Summary
- use OpenAI's JSON mode for reliable formatting
- increase allowed tokens in the completion to avoid truncated replies

## Testing
- `npm test` *(fails: no test specified)*
- `npm install`
- `node server.js` *(started and stopped without error)*

------
https://chatgpt.com/codex/tasks/task_e_684ccbc325008323a14ce1b0dfa5953c